### PR TITLE
Check and safely repair filesystem issues before resizing

### DIFF
--- a/pi-expand
+++ b/pi-expand
@@ -119,6 +119,9 @@ readonly LOOP_DEVICE
 # ROOTFS_PARTITION_NUMBER to create this string.
 readonly LOOP_DEVICE_PARTITION_LABEL="${LOOP_DEVICE}p${ROOTFS_PARTITION_NUMBER}"
 
+# Check and safely repair any filesystem issues.
+e2fsck -fp "${LOOP_DEVICE_PARTITION_LABEL}"
+
 # Resize the filesystem using the loop device to fill the expanded partition.
 sudo resize2fs "${LOOP_DEVICE_PARTITION_LABEL}"
 

--- a/pi-expand
+++ b/pi-expand
@@ -120,7 +120,7 @@ readonly LOOP_DEVICE
 readonly LOOP_DEVICE_PARTITION_LABEL="${LOOP_DEVICE}p${ROOTFS_PARTITION_NUMBER}"
 
 # Resize the filesystem using the loop device to fill the expanded partition.
-sudo resize2fs -f "${LOOP_DEVICE_PARTITION_LABEL}"
+sudo resize2fs "${LOOP_DEVICE_PARTITION_LABEL}"
 
 # Release our loop device.
 sudo losetup --detach "${LOOP_DEVICE}"

--- a/pi-expand
+++ b/pi-expand
@@ -120,7 +120,7 @@ readonly LOOP_DEVICE
 readonly LOOP_DEVICE_PARTITION_LABEL="${LOOP_DEVICE}p${ROOTFS_PARTITION_NUMBER}"
 
 # Resize the filesystem using the loop device to fill the expanded partition.
-sudo resize2fs "${LOOP_DEVICE_PARTITION_LABEL}"
+sudo resize2fs -f "${LOOP_DEVICE_PARTITION_LABEL}"
 
 # Release our loop device.
 sudo losetup --detach "${LOOP_DEVICE}"


### PR DESCRIPTION
While working on https://github.com/tiny-pilot/tinypilot-pro/pull/928, I ran into the following issue when trying to [expand the TinyPilot disk image in CI](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot-pro/2870/workflows/aec7b944-cc98-4cf5-8415-ecc3d34b8d6f/jobs/21663?invite=true#step-106-38):

```bash
+ LOOP_DEVICE_PARTITION_LABEL=/dev/loop1p2
+ sudo resize2fs /dev/loop1p2
resize2fs 1.45.5 (07-Jan-2020)
Please run 'e2fsck -f /dev/loop1p2' first.
```

[Someone suggested that it's a timezone issue](https://askubuntu.com/a/1361288/694328) between `parted` and the system. However, I can't see any issue in CI, the timezone is set to UTC.

As the error suggests, running `e2fsck -f` works, which basically checks (and repairs?) the filesystem.

This PR uses [`e2fsck`](https://man7.org/linux/man-pages/man8/e2fsck.8.html) to check (`-f`) and safely repair (`-p`) any filesystem issues before resizing the filesystem.

I have tested this fix in CI.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/pi-expand/3"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>